### PR TITLE
update DI Frameworks/Containers, add ididi

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Fresh Bakery](https://github.com/Mityuha/fresh-bakery) ★21 - Bake dependency injections asynchronously and stupidly simple. [🐍, MIT License].
 - [andi](https://github.com/scrapinghub/andi) ★21 - Library for annotation-based dependency injection. [🐍, BSD 3-Clause "New" or "Revised" License].
 - [Picodi](https://github.com/yakimka/picodi) ★22 - A DI library inspired by FastAPI. It integrates well with FastAPI but can also be used independently. [🐍, MIT License].
+- [ididi](https://github.com/raceychan/ididi) ★12  - Genius simplicity, unmathced power, dependency injection in a single line of code. [🐍, MIT License]
 - [Clean IoC](https://github.com/peter-daly/clean_ioc) ★9 - A simple unintrusive dependency injection library for python with strong support for generics [🐍, MIT License].
 - [injection](https://github.com/nightblure/injection) ★6 - replacement for [python-dependency-injector](https://github.com/ets-labs/python-dependency-injector) that works with Python 3.8-3.12 and works with FastAPI, DRF, Flask and Litestar [🐍, MIT License].
 - [Modern DI](https://github.com/modern-python/modern-di) ★3 - powerful DI-framework with scopes and IoC-container [🐍, MIT License].


### PR DESCRIPTION
add ididi to the list of DI frameworks

ididi is a pythonic di frameworks that gets the jobs done in a single line of code,
and does not require you to modify your existing code.

```pyt
import ididi

class UserService:
    def __init__(self, repo: UserRepository):
        self.repo = repo

user_service = ididi.resolve(UserService) 
```