### PR TITLE
docs: add Overlay to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [ididi](https://github.com/raceychan/ididi) ★18  - Genius simplicity, unmathced power, dependency injection in a single line of code. [🐍, MIT License]
 - [injection](https://github.com/nightblure/injection) ★17 - replacement for [python-dependency-injector](https://github.com/ets-labs/python-dependency-injector) that works with Python 3.8-3.12 and works with FastAPI, DRF, Flask and Litestar [🐍, MIT License].
 - [Clean IoC](https://github.com/peter-daly/clean_ioc) ★11 - A simple unintrusive dependency injection library for python with strong support for generics [🐍, MIT License].
+- [Overlay](https://overlaylanguage.readthedocs.io/en/latest/) ★0 - A dependency injection framework with pytest-fixture syntax, plus a configuration language for declarative programming [🐍, MIT License].
 
 ### DI components of Web frameworks
 


### PR DESCRIPTION
Hi, I'm the author of Overlay. It's a dependency injection framework with pytest-fixture syntax, plus a configuration language based on inheritance and deep merge.

I've spent several months on this. The design is backed by a formal calculus ([arXiv:2602.16291](https://arxiv.org/abs/2602.16291)), and the API has reached a point where I consider it stable. The test suite is thorough and I believe it is close to bug-free, so I think it's time to announce it.

The GitHub project includes 2 packages:
-  `overlay.language`: the DI framework and the configuration language
- `overlay.library`: the standard library for the language

The library part hasn't stabilized yet, so I'm only announcing `overlay.language` for now. For Python-first development using Overlay as a DI framework, `overlay.library` is not needed.

- PyPI: [overlay.language](https://pypi.org/project/overlay.language/), [overlay.library](https://pypi.org/project/overlay.library/)
- Docs: https://overlaylanguage.readthedocs.io/
- Github: https://github.com/Atry/overlay
- Paper: https://arxiv.org/abs/2602.16291
